### PR TITLE
build: add scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+on:
+  push:
+    branches:
+      - master
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Install Dependencies
+        run: yarn
+
+      - name: Create Release Pull Request
+        uses: changesets/action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "doc": "pnpm --filter=hel-doc run build && npm run cpdoc",
     "format": "prettier --cache --write . '!./pnpm-lock.yaml' '!./doc/src/components' --ignore-path .gitignore --ignore-unknown",
     "prepare": "husky install",
-    "release:auto": "pnpm build && pnpm version:all && pnpm release:all",
+    "release:auto": "pnpm build && pnpm version:all && pnpm release:all && pnpm sync",
     "changeset": "changeset",
     "release:all": "changeset publish",
     "version:all": "changelog version",

--- a/package.json
+++ b/package.json
@@ -11,13 +11,19 @@
   "main": "index.js",
   "scripts": {
     "build": "turbo run build",
+    "build:watch": "turbo run build:watch",
     "build_devtool": "pnpm --filter=helux-devtool run build",
     "build_helux": "pnpm --filter=helux run build",
     "commitlint": "commitlint -e $HUSKY_GIT_PARAMS",
     "cpdoc": "rm -rf ../my-opensource/helux-gh-pages/* && cp -r ./doc/build/* ../my-opensource/helux-gh-pages",
     "doc": "pnpm --filter=hel-doc run build && npm run cpdoc",
     "format": "prettier --cache --write . '!./pnpm-lock.yaml' '!./doc/src/components' --ignore-path .gitignore --ignore-unknown",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "release:auto": "pnpm build && pnpm version:all && pnpm release:all",
+    "changeset": "changeset",
+    "release:all": "changeset publish",
+    "version:all": "changelog version",
+    "sync":"cnpm sync helux && cnpm sync @helux/core && cnpm sync @helux/hooks && cnpm sync @helux/hooks-impl && cnpm sync @helux/types && cnpm sync @helux/utils"
   },
   "lint-staged": {
     "*.{js,jsx,less,md,json}": [

--- a/packages/helux-core/package.json
+++ b/packages/helux-core/package.json
@@ -28,6 +28,7 @@
   ],
   "scripts": {
     "build": "tsup",
+    "build:watch": "tsup --watch",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {

--- a/packages/helux-fre/package.json
+++ b/packages/helux-fre/package.json
@@ -27,6 +27,7 @@
   ],
   "scripts": {
     "build": "tsup",
+    "build:watch": "tsup --watch",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {

--- a/packages/helux-hooks-impl/package.json
+++ b/packages/helux-hooks-impl/package.json
@@ -27,6 +27,7 @@
   ],
   "scripts": {
     "build": "tsup",
+    "build:watch": "tsup --watch",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {

--- a/packages/helux-hooks/package.json
+++ b/packages/helux-hooks/package.json
@@ -31,6 +31,7 @@
   ],
   "scripts": {
     "build": "tsup",
+    "build:watch": "tsup --watch",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {

--- a/packages/helux-plugin-devtool/package.json
+++ b/packages/helux-plugin-devtool/package.json
@@ -27,6 +27,7 @@
   ],
   "scripts": {
     "build": "tsup",
+    "build:watch": "tsup --watch",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {

--- a/packages/helux-preact/package.json
+++ b/packages/helux-preact/package.json
@@ -27,6 +27,7 @@
   ],
   "scripts": {
     "build": "tsup",
+    "build:watch": "tsup --watch",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {

--- a/packages/helux-utils-legacy/package.json
+++ b/packages/helux-utils-legacy/package.json
@@ -29,6 +29,7 @@
   ],
   "scripts": {
     "build": "tsup",
+    "build:watch": "tsup --watch",
     "dev": "tsc --watch",
     "lint": "eslint ./src --fix --ext js,ts,tsx",
     "test": "jest"

--- a/packages/helux/package.json
+++ b/packages/helux/package.json
@@ -28,6 +28,7 @@
   ],
   "scripts": {
     "build": "tsup",
+    "build:watch": "tsup --watch",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -5,6 +5,10 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**"]
     },
+    "build:watch": {
+      "dependsOn": ["^build:watch"],
+      "outputs": ["dist/**"]
+    },
     "start": {
       "cache": false
     }


### PR DESCRIPTION
新增加一些script:

1.  `sync`:可以在构建后执行同步cnpm
2.  `build:watch` : 构建时监视文件变化自动重新构建，用于调试时
3.  `changeset`:  更改文件后运行用来生成changelog
4.  `release:all`:  发布所有包
5.  `release:auto`: 全自动化发布
6.  `version:all`: 提升版本消费changelog