### PR TITLE
fix: 修复`extraArgs`类型缺失

### DIFF
--- a/packages/helux-core/src/types/base.d.ts
+++ b/packages/helux-core/src/types/base.d.ts
@@ -330,6 +330,10 @@ export interface IMutateTaskParam<T = SharedState, P extends Arr = Arr, E extend
   /** deps 返回的结果 */
   input: P;
   extraBound: IBoundStateInfo<E>;
+    /**
+   * 额外参数，用来传递给 mutate 的fn和task函数
+   */
+  extraArgs?: any;
 }
 
 /**


### PR DESCRIPTION
上次的PR包含有两次提交，其中第一次是错误的，第二次改正了


本次恢复了，重新提交